### PR TITLE
Add a simple benchmark

### DIFF
--- a/bench/Benchmark.hs
+++ b/bench/Benchmark.hs
@@ -1,0 +1,9 @@
+import Disclaimer
+
+import Criterion.Main
+
+main = defaultMain
+    [ bgroup "rectArea"
+        [ bench "unit square"     $ whnf (rectArea     1)     1
+        , bench "large rectangle" $ whnf (rectArea 12345) 67890 ]
+    ]

--- a/package.yaml
+++ b/package.yaml
@@ -27,3 +27,11 @@ tests:
       - hspec
       - QuickCheck
       - transformers
+
+benchmarks:
+  bench:
+    main: Benchmark.hs
+    source-dirs: bench
+    dependencies:
+      - disclaimer
+      - criterion


### PR DESCRIPTION
To make the project's structure complete, I added a example benchmark.

To run the benchmark, just type:

```
stack bench
```

Or, *if you are using Stack with **Nix***:

```
stack bench --no-nix-pure
```

To create a [beautiful HTML output](http://www.serpentine.com/criterion/fibber.html), type:

```
stack bench --benchmark-arguments='--output=benchmark.html'
```

Or, *if you are using Stack with **Nix***:
```
stack bench --no-nix-pure --benchmark-arguments='--output=benchmark.html'
```