### PR TITLE
Fix errors and warnings

### DIFF
--- a/bench/Benchmark.hs
+++ b/bench/Benchmark.hs
@@ -2,6 +2,7 @@ import Disclaimer
 
 import Criterion.Main
 
+main :: IO ()
 main = defaultMain
     [ bgroup "rectArea"
         [ bench "unit square"     $ whnf (rectArea     1)     1

--- a/src/Disclaimer.hs
+++ b/src/Disclaimer.hs
@@ -4,7 +4,6 @@ module Disclaimer (
         rectArea) where
 
 import Control.Applicative
-import Control.Monad.Trans.Writer
 import WriterCopy
 import Data.Function
 

--- a/src/Disclaimer.hs
+++ b/src/Disclaimer.hs
@@ -1,5 +1,6 @@
 module Disclaimer (
         WriterCopy.runWriter,
+        fixLegacyNum,
         safeRectArea,
         rectArea) where
 

--- a/src/Disclaimer.hs
+++ b/src/Disclaimer.hs
@@ -1,7 +1,7 @@
 module Disclaimer (
-	WriterCopy.runWriter,
-	safeRectArea,
-	rectArea) where
+        WriterCopy.runWriter,
+        safeRectArea,
+        rectArea) where
 
 import Control.Applicative
 import Control.Monad.Trans.Writer

--- a/test/DisclaimerSpec.hs
+++ b/test/DisclaimerSpec.hs
@@ -2,7 +2,6 @@ module DisclaimerSpec where
 
 import Disclaimer
 
-import Control.Monad.Trans.Writer
 import Test.Hspec
 import Test.QuickCheck
 


### PR DESCRIPTION
This PR fixes some errors and warnings to allow the project to build cleanly again.

### About warnings

It is a good idea to always compile the project with `-Wall -Werror` or, when using *Stack*, with `--pedantic`. It has the effect of enabling all warnings and transforming them in errors.

In this project, to test everything before committing, you would have to write:

```
$ stack clean
$ stack test --pedantic --bench --no-run-benchmarks
```

### About commit messages

The commit messages below give a short description of the warnings/errors fixed, but they are far from good, because I'm sleepy 😴 now. Just in case you are wondering, here is a good reference about how to write good commit messages:

https://chris.beams.io/posts/git-commit/